### PR TITLE
Correction made in axil_eio_litex_wrapper.py

### DIFF
--- a/rapidsilicon/ip/axil_eio/v1_0/litex_wrapper/axil_eio_litex_wrapper.py
+++ b/rapidsilicon/ip/axil_eio/v1_0/litex_wrapper/axil_eio_litex_wrapper.py
@@ -104,7 +104,7 @@ class AXILEIO(Module):
             o_S_AXI_RDATA    = s_axil.r.data,
             o_S_AXI_RRESP    = s_axil.r.resp,
             o_S_AXI_RVALID   = s_axil.r.valid,
-            i_S_AXI_RVALID   = s_axil.r.ready
+            i_S_AXI_RREADY   = s_axil.r.ready
         )
         
         # Add Sources.


### PR DESCRIPTION
There was a typo in axil_eio_litex_wrapper.py which caused the generated wrapper to inherit the typo as well. This caused duplicate ports in the eio_top instance and the synthesis ultimately failed. This has been fixed and the synthesis goes through fine.