### PR TITLE
FIFO_Generator empty with reset patch

### DIFF
--- a/rapidsilicon/README.md
+++ b/rapidsilicon/README.md
@@ -23,6 +23,7 @@ IP Catalog is an IP library for Raptor toolchain.
 			ip/
 			├── ahb2axi_bridge
 			├── ahb_sram
+			├── axi2ahb_bridge
 			├── axi2axilite_bridge
 			├── axi_async_fifo
 			├── axi_cdma

--- a/rapidsilicon/ip/fifo_generator/v1_0/litex_wrapper/fifo_litex_generator.py
+++ b/rapidsilicon/ip/fifo_generator/v1_0/litex_wrapper/fifo_litex_generator.py
@@ -3368,13 +3368,16 @@ class FIFO(Module):
                 # Checking if the FIFO is empty
                 if (data_width_write >= data_width_read):
                     self.comb += [
-                        If(self.counter == 0,
-                           self.empty.eq(1)
-                           ).Elif(self.pessimistic_empty == 2,
-                           self.empty.eq(0)
-                           ).Else(
+                        If (ResetSignal("sys"),
+                            self.empty.eq(1)
+                            ).Elif(self.counter == 0,
+                            self.empty.eq(1)
+                            ).Elif(self.pessimistic_empty == 2,
+                            self.empty.eq(0)
+                            ).Else(
                                self.empty.eq(1)
                            )
+                        
                     ]
                     # Checking for Programmable Empty
                     if (empty_threshold):
@@ -3385,7 +3388,9 @@ class FIFO(Module):
                         ]
                 else:
                     self.comb += [
-                        If(self.counter <= clocks_for_output,
+                        If (ResetSignal("sys"),
+                            self.empty.eq(1)
+                            ).Elif(self.counter <= clocks_for_output,
                            self.empty.eq(1)
                            ).Elif(self.pessimistic_empty == 2,
                            self.empty.eq(0)
@@ -3517,7 +3522,9 @@ class FIFO(Module):
                 # Checking if the FIFO is empty
                 if (data_width_write > data_width_read):
                     self.comb += [
-                        If(self.rd_ptr == self.sync_rdclk_wrtptr_binary_multiple,
+                        If (ResetSignal("rd"),
+                            self.empty.eq(1)
+                            ).Elif(self.rd_ptr == self.sync_rdclk_wrtptr_binary_multiple,
                            self.empty.eq(1)
                            ).Elif(self.pessimistic_empty == 2,
                            self.empty.eq(0)
@@ -3560,7 +3567,9 @@ class FIFO(Module):
                         ]
                 elif (data_width_write == data_width_read):
                     self.comb += [
-                        If(self.rd_ptr == self.sync_rdclk_wrtptr_binary,
+                        If (ResetSignal("rd"),
+                            self.empty.eq(1)
+                            ).Elif(self.rd_ptr == self.sync_rdclk_wrtptr_binary,
                            self.empty.eq(1)
                            ).Elif(self.pessimistic_empty == 2,
                            self.empty.eq(0)
@@ -3603,7 +3612,9 @@ class FIFO(Module):
                         ]
                 else:
                     self.comb += [
-                        If(self.rd_pointer_multiple == self.sync_rdclk_wrtptr_binary,
+                        If (ResetSignal("rd"),
+                            self.empty.eq(1)
+                            ).Elif(self.rd_pointer_multiple == self.sync_rdclk_wrtptr_binary,
                            self.empty.eq(1)
                            ).Elif(self.pessimistic_empty == 2,
                            self.empty.eq(0)


### PR DESCRIPTION
- Asserted empty signal when global reset applied, fixing netlist simulation
- Updated README with newly added IP